### PR TITLE
Disambiguate between IP addresses and hostnames

### DIFF
--- a/simplesocks/src/main/java/org/connectbot/simplesocks/Socks5Server.java
+++ b/simplesocks/src/main/java/org/connectbot/simplesocks/Socks5Server.java
@@ -18,7 +18,10 @@ package org.connectbot.simplesocks;
 
 import java.io.*;
 import java.net.InetAddress;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
 
 /**
  * A simple SOCKS5 server which does no authentication and only accepts {@code CONNECT} requests (i.e., no
@@ -143,9 +146,14 @@ public class Socks5Server {
     private Command command;
 
     /**
-     * Address requested when the {@link Command} was given.
+     * IP address requested when the {@link Command} was given.
      */
     private InetAddress address;
+
+    /**
+     * Hostname requested when the {@link Command} was given.
+     */
+    private String hostName;
 
     /**
      * The port requested when the {@link Command} was given.
@@ -228,7 +236,12 @@ public class Socks5Server {
             int hostNameLength = in.read();
             byte[] hostName = new byte[hostNameLength];
             in.readFully(hostName);
-            address = InetAddress.getByName(new String(hostName, Charset.forName("US-ASCII")));
+
+            // We use this so we have an IOException thrown instead of an unchecked exception.
+            CharsetDecoder asciiDecoder = Charset.forName("US-ASCII").newDecoder();
+            CharBuffer hostBuffer = asciiDecoder.decode(ByteBuffer.wrap(hostName));
+
+            this.hostName = hostBuffer.toString();
         } else if (atype == ATYPE_IPV6) {
             byte[] addressBytes = new byte[16];
             in.readFully(addressBytes);
@@ -268,6 +281,10 @@ public class Socks5Server {
 
     public InetAddress getAddress() {
         return address;
+    }
+
+    public String getHostName() {
+        return hostName;
     }
 
     public int getPort() {

--- a/simplesocks/src/test/java/org/connectbot/simplesocks/Socks5ServerTest.java
+++ b/simplesocks/src/test/java/org/connectbot/simplesocks/Socks5ServerTest.java
@@ -74,7 +74,6 @@ public class Socks5ServerTest {
         Socks5Server server = getAuthenticatedSocks5Server((byte) 0x05, (byte) 0x01, (byte) 0x00,
                 (byte) 0x01, (byte) 0x01, (byte) 0x00, (byte) 0x01, (byte) 0xC0, (byte) 0xA8, (byte) 0x01, (byte) 0x01);
         assertTrue(server.readRequest());
-        assertArrayEquals(new byte[]{(byte) 0xC0, (byte) 0xA8, (byte) 0x01, (byte) 0x01}, server.getAddress().getAddress());
     }
 
     @Test(expected = IOException.class)
@@ -82,7 +81,6 @@ public class Socks5ServerTest {
         Socks5Server server = getAuthenticatedSocks5Server((byte) 0x05, (byte) 0x01, (byte) 0x00,
                 (byte) 0x01, (byte) 0x01, (byte) 0x10, (byte) 0x01, (byte) 0xC0, (byte) 0xA8, (byte) 0x01, (byte) 0x01);
         assertTrue(server.readRequest());
-        assertArrayEquals(new byte[]{(byte) 0xC0, (byte) 0xA8, (byte) 0x01, (byte) 0x01}, server.getAddress().getAddress());
     }
 
     @Test
@@ -101,6 +99,7 @@ public class Socks5ServerTest {
         assertTrue(server.readRequest());
         assertEquals(Socks5Server.Command.CONNECT, server.getCommand());
         assertArrayEquals(new byte[]{(byte) 0xC0, (byte) 0xA8, (byte) 0x01, (byte) 0x01}, server.getAddress().getAddress());
+        assertNull(server.getHostName());
         assertEquals(2001, server.getPort());
     }
 
@@ -112,7 +111,8 @@ public class Socks5ServerTest {
                 (byte) 0x22, (byte) 0xB8);
         assertTrue(server.readRequest());
         assertEquals(Socks5Server.Command.CONNECT, server.getCommand());
-        assertEquals("example.com", server.getAddress().getHostName());
+        assertEquals("example.com", server.getHostName());
+        assertNull(server.getAddress());
         assertEquals(8888, server.getPort());
     }
 
@@ -133,6 +133,7 @@ public class Socks5ServerTest {
                 (byte) 0xA5, (byte) 0x5A, (byte) 0xFF, (byte) 0x02,
                 (byte) 0xCC, (byte) 0xAA, (byte) 0x01, (byte) 0x10,
                 (byte) 0x00, (byte) 0x00, (byte) 0xD0, (byte) 0x0D}, server.getAddress().getAddress());
+        assertNull(server.getHostName());
         assertEquals(16302, server.getPort());
     }
 
@@ -145,6 +146,7 @@ public class Socks5ServerTest {
         assertTrue(server.readRequest());
         assertEquals(Socks5Server.Command.BIND, server.getCommand());
         assertArrayEquals(new byte[]{(byte) 0xC0, (byte) 0xA8, (byte) 0x01, (byte) 0x01}, server.getAddress().getAddress());
+        assertNull(server.getHostName());
         assertEquals(1080, server.getPort());
     }
 


### PR DESCRIPTION
This will allow us to resolve hostnames on the other side of the
connection to make sure we don't leak DNS information.
