### PR TITLE
Travis-CI: Use OpenJDK instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_cache:
 
 matrix:
   include:
-    - jdk: oraclejdk9
-    - jdk: oraclejdk8
+    - jdk: openjdk9
+    - jdk: openjdk8
       env: COVERAGE="true" RELEASE="true"
 
 after_success:

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,5 +25,5 @@ description=SOCKS library for Java
 bintrayUser=dummyUser
 bintrayApiKey=dummyApiKey
 
-officialJdk=oraclejdk7
+officialJdk=openjdk8
 gitHubUrl=https\://github.com/kruton/simplesocks

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ bintrayUser=dummyUser
 bintrayApiKey=dummyApiKey
 
 officialJdk=openjdk8
-gitHubUrl=https\://github.com/kruton/simplesocks
+gitHubUrl=https\://github.com/connectbot/simplesocks


### PR DESCRIPTION
The new license for Oracle JDK downloads seem something worthy
of avoidance.